### PR TITLE
Fix: Ethereum concurrency submission

### DIFF
--- a/app/clients/ethereum/ethereum.go
+++ b/app/clients/ethereum/ethereum.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethclient"
@@ -35,6 +36,13 @@ func (ec *EthereumClient) ValidateContractAddress(contractAddress string) (*comm
 
 func (ec *EthereumClient) WaitForTransactionSuccess(hash common.Hash) (isSuccessful bool, err error) {
 	receipt, err := ec.waitForTransactionReceipt(hash)
+
+	// try again mechanism in case transaction is not validated for tx mempool yet
+	if errors.Is(err, ethereum.NotFound) {
+		time.Sleep(5 * time.Second)
+		receipt, err = ec.waitForTransactionReceipt(hash)
+	}
+
 	if err != nil {
 		return false, err
 	}

--- a/app/clients/ethereum/ethereum.go
+++ b/app/clients/ethereum/ethereum.go
@@ -47,8 +47,9 @@ func (ec *EthereumClient) WaitForTransactionSuccess(hash common.Hash) (isSuccess
 func (ec *EthereumClient) waitForTransactionReceipt(hash common.Hash) (txReceipt *types.Receipt, err error) {
 	for {
 		_, isPending, err := ec.Client.TransactionByHash(context.Background(), hash)
+
 		// try again mechanism in case transaction is not validated for tx mempool yet
-		if errors.Is(err, ethereum.NotFound) {
+		if errors.Is(ethereum.NotFound, err) {
 			time.Sleep(5 * time.Second)
 			_, isPending, err = ec.Client.TransactionByHash(context.Background(), hash)
 		}

--- a/app/services/ethereum/bridge/service.go
+++ b/app/services/ethereum/bridge/service.go
@@ -12,14 +12,19 @@ import (
 	"github.com/limechain/hedera-eth-bridge-validator/proto"
 	log "github.com/sirupsen/logrus"
 	"strconv"
+	"sync"
 )
 
 type BridgeContractService struct {
 	contractInstance *bridge.Bridge
 	Client           *ethclient.EthereumClient
+	mutex            sync.Mutex
 }
 
 func (bsc *BridgeContractService) SubmitSignatures(opts *bind.TransactOpts, ctm *proto.CryptoTransferMessage, signatures [][]byte) (*types.Transaction, error) {
+	bsc.mutex.Lock()
+	defer bsc.mutex.Unlock()
+
 	amountBn, err := helper.ToBigInt(strconv.Itoa(int(ctm.Amount)))
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
**Detailed description**:
* Add mutex to `SubmitSignatures` concurrent submission
* Try-again mechanism for transaction hash in case transaction is not validated for tx mempool yet

**Which issue(s) this PR fixes**:
Fixes #None

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated