### PR TITLE
Fix: Do not schedule TX for execution if operator is not amongst the enough collected signatures

### DIFF
--- a/app/process/handler/consensus-message/consensus-message.go
+++ b/app/process/handler/consensus-message/consensus-message.go
@@ -158,11 +158,11 @@ func (cmh ConsensusMessageHandler) handleSignatureMessage(msg *validatorproto.To
 	}
 
 	if cmh.enoughSignaturesCollected(txMessages, m.TransactionId) {
-		cmh.logger.Debugf("Enough signatures have been collected for Transaction ID [%s].", m.TransactionId)
+		cmh.logger.Debugf("TX [%s] - Enough signatures have been collected.", m.TransactionId)
 
 		slot, isFound := cmh.computeExecutionSlot(txMessages)
 		if !isFound {
-			cmh.logger.Debugf("Operator [%s] has not been found amongst the signatures collected for Transaction ID [%s].", cmh.signer.Address(), m.TransactionId)
+			cmh.logger.Debugf("TX [%s] - Operator [%s] has not been found as signer amongst the signatures collected.", m.TransactionId, cmh.signer.Address())
 			return nil
 		}
 

--- a/app/process/handler/consensus-message/consensus-message.go
+++ b/app/process/handler/consensus-message/consensus-message.go
@@ -152,17 +152,27 @@ func (cmh ConsensusMessageHandler) handleSignatureMessage(msg *validatorproto.To
 
 	cmh.logger.Debugf("Verified and saved signature for TX ID [%s]", m.TransactionId)
 
-	txSignatures, err := cmh.repository.GetTransactions(m.TransactionId, hexHash)
+	txMessages, err := cmh.repository.GetTransactions(m.TransactionId, hexHash)
 	if err != nil {
-		return errors.New(fmt.Sprintf("Could not retrieve transaction messages for Transaction ID [%s]. Error [%s]", m.TransactionId))
+		return errors.New(fmt.Sprintf("Could not retrieve transaction messages for Transaction ID [%s]. Error [%s]", m.TransactionId, err))
 	}
 
-	if cmh.enoughSignaturesCollected(txSignatures, m.TransactionId) {
-		submission := &ethsubmission.Submission{
-			TransactOps:           cmh.signer.NewKeyTransactor(),
-			CryptoTransferMessage: ctm,
-			Messages:              txSignatures,
+	if cmh.enoughSignaturesCollected(txMessages, m.TransactionId) {
+		cmh.logger.Debugf("Enough signatures have been collected for Transaction ID [%s].", m.TransactionId)
+
+		slot, isFound := cmh.computeExecutionSlot(txMessages)
+		if !isFound {
+			cmh.logger.Debugf("Operator [%s] has not been found amongst the signatures collected for Transaction ID [%s].", cmh.signer.Address(), m.TransactionId)
+			return nil
 		}
+
+		submission := &ethsubmission.Submission{
+			CryptoTransferMessage: ctm,
+			Messages:              txMessages,
+			Slot:                  slot,
+			TransactOps:           cmh.signer.NewKeyTransactor(),
+		}
+
 		err := cmh.scheduler.Schedule(m.TransactionId, *submission)
 		if err != nil {
 			return err
@@ -186,6 +196,18 @@ func (cmh ConsensusMessageHandler) enoughSignaturesCollected(txSignatures []mess
 	requiredSigCount := len(cmh.operatorsEthAddresses)/2 + 1
 	cmh.logger.Infof("Collected [%d/%d] Signatures for TX ID [%s] ", len(txSignatures), len(cmh.operatorsEthAddresses), transactionId)
 	return len(txSignatures) >= requiredSigCount
+}
+
+// computeExecutionSlot - computes the slot order in which the TX will execute
+// Important! Transaction messages ARE expected to be sorted by ascending Timestamp
+func (cmh ConsensusMessageHandler) computeExecutionSlot(messages []message.TransactionMessage) (slot int64, isFound bool) {
+	for i := 0; i < len(messages); i++ {
+		if strings.ToLower(messages[i].SignerAddress) == strings.ToLower(cmh.signer.Address()) {
+			return int64(i), true
+		}
+	}
+
+	return -1, false
 }
 
 func (cmh ConsensusMessageHandler) isValidAddress(key string) bool {

--- a/app/process/model/ethsubmission/ethsubmission.go
+++ b/app/process/model/ethsubmission/ethsubmission.go
@@ -10,4 +10,5 @@ type Submission struct {
 	TransactOps           *bind.TransactOpts
 	CryptoTransferMessage *proto.CryptoTransferMessage
 	Messages              []message.TransactionMessage
+	Slot                  int64
 }

--- a/app/process/watcher/crypto-transfer/crypto-transfer.go
+++ b/app/process/watcher/crypto-transfer/crypto-transfer.go
@@ -14,7 +14,6 @@ import (
 	"github.com/limechain/hedera-eth-bridge-validator/app/process/watcher/publisher"
 	"github.com/limechain/hedera-eth-bridge-validator/config"
 	protomsg "github.com/limechain/hedera-eth-bridge-validator/proto"
-	"github.com/limechain/hedera-state-proof-verifier-go/stateproof"
 	"github.com/limechain/hedera-watcher-sdk/queue"
 	log "github.com/sirupsen/logrus"
 	"gorm.io/gorm"
@@ -171,22 +170,23 @@ func (ctw CryptoTransferWatcher) processTransaction(tx transaction.HederaTransac
 		return
 	}
 
-	stateProof, e := ctw.client.GetStateProof(tx.TransactionID)
+	_, e = ctw.client.GetStateProof(tx.TransactionID)
 	if e != nil {
 		ctw.logger.Errorf("Could not GET state proof, TransactionID [%s]. Error [%s]", tx.TransactionID, e)
 		return
 	}
 
-	verified, e := stateproof.Verify(tx.TransactionID, stateProof)
-	if e != nil {
-		ctw.logger.Errorf("Error while trying to verify state proof for TransactionID [%s]. Error [%s]", tx.TransactionID, e)
-		return
-	}
-
-	if !verified {
-		ctw.logger.Errorf("Failed to verify state proof for TransactionID [%s]", tx.TransactionID)
-		return
-	}
+	// TODO: Uncomment after support for V5 record and signature files has been added
+	//verified, e := stateproof.Verify(tx.TransactionID, stateProof)
+	//if e != nil {
+	//	ctw.logger.Errorf("Error while trying to verify state proof for TransactionID [%s]. Error [%s]", tx.TransactionID, e)
+	//	return
+	//}
+	//
+	//if !verified {
+	//	ctw.logger.Errorf("Failed to verify state proof for TransactionID [%s]", tx.TransactionID)
+	//	return
+	//}
 
 	information := &protomsg.CryptoTransferMessage{
 		TransactionId: tx.TransactionID,


### PR DESCRIPTION
**Detailed description**:
* Do not schedule tx for execution if operator is not found as signer amongst the enough collected sigs so far
* Add debug logs where appropriate

**Which issue(s) this PR fixes**:
Fixes #None

**Special notes for your reviewer**:
* State proof verification has been commented until support for V5 files added.

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

