### PR TITLE
Fix(e2e): pad left transaction id nanoseconds with zeros

### DIFF
--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -312,7 +312,7 @@ func fromHederaTransactionID(id *hedera.TransactionID) hederaTxId {
 	return hederaTxId{
 		AccountId: accId,
 		Seconds:   split[0],
-		Nanos:     split[1],
+		Nanos:     fmt.Sprintf("%09s", split[1]),
 	}
 }
 


### PR DESCRIPTION
**Detailed description**:
* Pad left Transfer TransactionID nanoseconds with zeros - Mirror Node pads to 9 symbols, thus making transaction ids inconsistent.

**Which issue(s) this PR fixes**:
Fixes #160 

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

