### PR TITLE
Fix(message-watcher): poll messages instead of subscribing via sdk

### DIFF
--- a/app/clients/hedera/mirror-node/client.go
+++ b/app/clients/hedera/mirror-node/client.go
@@ -73,6 +73,15 @@ func (c Client) GetAccountCreditTransactionsBetween(accountId hedera.AccountID, 
 	return res, nil
 }
 
+// GetMessagesAfterTimestamp returns all Topic messages after the given timestamp
+func (c Client) GetMessagesAfterTimestamp(topicId hedera.TopicID, from int64) ([]Message, error) {
+	messagesQuery := fmt.Sprintf("/%s/messages?timestamp=gt:%s",
+		topicId.String(),
+		timestampHelper.String(from))
+
+	return c.getTopicMessagesByQuery(messagesQuery)
+}
+
 // GetMessagesForTopicBetween returns all Topic messages for the specified topic between timestamp `from` and `to` excluded
 func (c Client) GetMessagesForTopicBetween(topicId hedera.TopicID, from, to int64) ([]Message, error) {
 	transactionsDownloadQuery := fmt.Sprintf("/%s/messages?timestamp=gt:%s",

--- a/app/domain/client/mirror-node.go
+++ b/app/domain/client/mirror-node.go
@@ -25,6 +25,7 @@ type MirrorNode interface {
 	GetAccountCreditTransactionsAfterTimestamp(accountId hedera.AccountID, from int64) (*mirror_node.Response, error)
 	// GetAccountCreditTransactionsBetween returns all incoming Transfers for the specified account between timestamp `from` and `to` excluded
 	GetAccountCreditTransactionsBetween(accountId hedera.AccountID, from, to int64) ([]mirror_node.Transaction, error)
+	GetMessagesAfterTimestamp(topicId hedera.TopicID, from int64) ([]mirror_node.Message, error)
 	// GetMessagesForTopicBetween returns all topic messages for a given topic between timestamp `from` included and `to` excluded
 	GetMessagesForTopicBetween(topicId hedera.TopicID, from, to int64) ([]mirror_node.Message, error)
 	GetAccountTransaction(transactionID string) (*mirror_node.Response, error)

--- a/app/domain/client/mirror-node.go
+++ b/app/domain/client/mirror-node.go
@@ -25,6 +25,7 @@ type MirrorNode interface {
 	GetAccountCreditTransactionsAfterTimestamp(accountId hedera.AccountID, from int64) (*mirror_node.Response, error)
 	// GetAccountCreditTransactionsBetween returns all incoming Transfers for the specified account between timestamp `from` and `to` excluded
 	GetAccountCreditTransactionsBetween(accountId hedera.AccountID, from, to int64) ([]mirror_node.Transaction, error)
+	// GetMessagesAfterTimestamp returns all topic messages after the given timestamp
 	GetMessagesAfterTimestamp(topicId hedera.TopicID, from int64) ([]mirror_node.Message, error)
 	// GetMessagesForTopicBetween returns all topic messages for a given topic between timestamp `from` included and `to` excluded
 	GetMessagesForTopicBetween(topicId hedera.TopicID, from, to int64) ([]mirror_node.Message, error)

--- a/app/process/watcher/message/watcher.go
+++ b/app/process/watcher/message/watcher.go
@@ -102,7 +102,7 @@ func (cmw Watcher) beginWatching(q *pair.Queue) {
 		for _, msg := range messages {
 			milestoneTimestamp, err = timestamp.FromString(msg.ConsensusTimestamp)
 			if err != nil {
-				cmw.logger.Errorf("Watcher [%s] - Unable to parse latest transaction timestamp. Error - [%s].", cmw.topicID.String(), err)
+				cmw.logger.Errorf("Unable to parse latest message timestamp. Error - [%s].", err)
 				continue
 			}
 			cmw.processMessage(msg, q)

--- a/app/process/watcher/message/watcher.go
+++ b/app/process/watcher/message/watcher.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/hashgraph/hedera-sdk-go/v2"
+	mirror_node "github.com/limechain/hedera-eth-bridge-validator/app/clients/hedera/mirror-node"
 	"github.com/limechain/hedera-eth-bridge-validator/app/core/pair"
 	"github.com/limechain/hedera-eth-bridge-validator/app/domain/client"
 	"github.com/limechain/hedera-eth-bridge-validator/app/domain/repository"
@@ -32,24 +33,28 @@ import (
 )
 
 type Watcher struct {
-	nodeClient       client.HederaNode
+	client           client.MirrorNode
 	topicID          hedera.TopicID
 	statusRepository repository.Status
+	pollingInterval  time.Duration
+	maxRetries       int
 	startTimestamp   int64
 	logger           *log.Entry
 }
 
-func NewWatcher(nodeClient client.HederaNode, topicID string, repository repository.Status, startTimestamp int64) *Watcher {
+func NewWatcher(client client.MirrorNode, topicID string, repository repository.Status, pollingInterval time.Duration, maxRetries int, startTimestamp int64) *Watcher {
 	id, err := hedera.TopicIDFromString(topicID)
 	if err != nil {
 		log.Fatalf("Could not start Consensus Topic Watcher for topic [%s] - Error: [%s]", topicID, err)
 	}
 
 	return &Watcher{
-		nodeClient:       nodeClient,
+		client:           client,
 		topicID:          id,
 		statusRepository: repository,
 		startTimestamp:   startTimestamp,
+		pollingInterval:  pollingInterval,
+		maxRetries:       maxRetries,
 		logger:           config.GetLoggerFor(fmt.Sprintf("[%s] Topic Watcher", topicID)),
 	}
 }
@@ -70,7 +75,7 @@ func (cmw Watcher) Watch(q *pair.Queue) {
 	} else {
 		cmw.updateStatusTimestamp(cmw.startTimestamp)
 	}
-	cmw.subscribeToTopic(q)
+	cmw.beginWatching(q)
 }
 
 func (cmw Watcher) updateStatusTimestamp(ts int64) {
@@ -81,34 +86,49 @@ func (cmw Watcher) updateStatusTimestamp(ts int64) {
 	cmw.logger.Tracef("Updated Topic Watcher timestamp to [%s]", timestamp.ToHumanReadable(ts))
 }
 
-func (cmw Watcher) subscribeToTopic(q *pair.Queue) {
-	_, err := hedera.NewTopicMessageQuery().
-		SetStartTime(time.Unix(0, cmw.startTimestamp)).
-		SetTopicID(cmw.topicID).
-		Subscribe(
-			cmw.nodeClient.GetClient(),
-			func(topicMsg hedera.TopicMessage) {
-				cmw.processMessage(topicMsg, q)
-				cmw.updateStatusTimestamp(topicMsg.ConsensusTimestamp.UnixNano())
-			},
-		)
+func (cmw Watcher) beginWatching(q *pair.Queue) {
+	milestoneTimestamp := cmw.startTimestamp
 
-	if err != nil {
-		cmw.logger.Error("Failed to subscribe to topic")
-		return
+	for {
+		messages, err := cmw.client.GetMessagesAfterTimestamp(cmw.topicID, milestoneTimestamp)
+		if err != nil {
+			cmw.logger.Errorf("Error while retrieving messages from mirror node. Error [%s]", err)
+			cmw.restart(q)
+		}
+
+		cmw.logger.Tracef("Polling found [%d] Messages", len(messages))
+
+		for _, msg := range messages {
+			milestoneTimestamp, err = timestamp.FromString(msg.ConsensusTimestamp)
+			if err != nil {
+				cmw.logger.Errorf("Watcher [%s] - Unable to parse latest transaction timestamp. Error - [%s].", cmw.topicID.String(), err)
+				continue
+			}
+			cmw.processMessage(msg, q)
+			cmw.updateStatusTimestamp(milestoneTimestamp)
+		}
+		time.Sleep(cmw.pollingInterval * time.Second)
 	}
-	cmw.logger.Infof("Subscribed to Messages after Timestamp [%s]", timestamp.ToHumanReadable(cmw.startTimestamp))
 }
 
-func (cmw Watcher) processMessage(topicMsg hedera.TopicMessage, q *pair.Queue) {
+func (cmw Watcher) processMessage(topicMsg mirror_node.Message, q *pair.Queue) {
 	cmw.logger.Info("New Message Received")
 
-	messageTimestamp := topicMsg.ConsensusTimestamp.UnixNano()
-	msg, err := message.FromBytesWithTS(topicMsg.Contents, messageTimestamp)
+	msg, err := message.FromString(topicMsg.Contents, topicMsg.ConsensusTimestamp)
 	if err != nil {
 		cmw.logger.Errorf("Could not decode incoming message [%s]. Error: [%s]", topicMsg.Contents, err)
 		return
 	}
 
 	q.Push(&pair.Message{Payload: msg})
+}
+
+func (cmw *Watcher) restart(q *pair.Queue) {
+	if cmw.maxRetries > 0 {
+		cmw.maxRetries--
+		cmw.logger.Infof("Watcher is trying to reconnect. Connections left [%d]", cmw.maxRetries)
+		go cmw.Watch(q)
+		return
+	}
+	cmw.logger.Errorf("Watcher failed: [Too many retries]")
 }

--- a/app/process/watcher/message/watcher.go
+++ b/app/process/watcher/message/watcher.go
@@ -94,6 +94,7 @@ func (cmw Watcher) beginWatching(q *pair.Queue) {
 		if err != nil {
 			cmw.logger.Errorf("Error while retrieving messages from mirror node. Error [%s]", err)
 			cmw.restart(q)
+			return
 		}
 
 		cmw.logger.Tracef("Polling found [%d] Messages", len(messages))

--- a/app/process/watcher/transfer/watcher.go
+++ b/app/process/watcher/transfer/watcher.go
@@ -159,7 +159,7 @@ func (ctw Watcher) processTransaction(tx mirror_node.Transaction, q *pair.Queue)
 	q.Push(&pair.Message{Payload: transferMessage})
 }
 
-func (ctw Watcher) restart(q *pair.Queue) {
+func (ctw *Watcher) restart(q *pair.Queue) {
 	if ctw.maxRetries > 0 {
 		ctw.maxRetries--
 		ctw.logger.Infof("Watcher is trying to reconnect")

--- a/app/process/watcher/transfer/watcher.go
+++ b/app/process/watcher/transfer/watcher.go
@@ -125,7 +125,7 @@ func (ctw Watcher) beginWatching(q *pair.Queue) {
 			var err error
 			milestoneTimestamp, err = timestamp.FromString(transactions.Transactions[len(transactions.Transactions)-1].ConsensusTimestamp)
 			if err != nil {
-				ctw.logger.Errorf("Watcher [%s] - Unable to parse latest transaction timestamp. Error - [%s].", ctw.accountID.String(), err)
+				ctw.logger.Errorf("Unable to parse latest transfer timestamp. Error - [%s].", err)
 				continue
 			}
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -121,7 +121,7 @@ func initializeServerPairs(server *server.Server, services *Services, repositori
 	server.AddPair(
 		addConsensusTopicWatcher(
 			&configuration,
-			clients.HederaNode,
+			clients.MirrorNode,
 			repositories.messageStatus,
 			watchersTimestamp),
 		cmh.NewHandler(
@@ -155,11 +155,16 @@ func addTransferWatcher(configuration *config.Config,
 }
 
 func addConsensusTopicWatcher(configuration *config.Config,
-	hederaNodeClient client.HederaNode,
+	client client.MirrorNode,
 	repository repository.Status,
 	startTimestamp int64,
 ) *cmw.Watcher {
 	topic := configuration.Hedera.Watcher.ConsensusMessage.Topic
 	log.Debugf("Added Topic Watcher for topic [%s]\n", topic.Id)
-	return cmw.NewWatcher(hederaNodeClient, topic.Id, repository, startTimestamp)
+	return cmw.NewWatcher(client,
+		topic.Id,
+		repository,
+		configuration.Hedera.MirrorNode.PollingInterval,
+		topic.MaxRetries,
+		startTimestamp)
 }


### PR DESCRIPTION
**Detailed description**:
* Sdk subscription stops receiving messages after undefined time. Due to its odd behaviour, I have decided that polling the mirror node would be more reliable.

**Which issue(s) this PR fixes**:
Fixes #None

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

