### PR TITLE
Correct Choice of Timestamp on Restart

### DIFF
--- a/app/clients/hedera/mirror-node/client.go
+++ b/app/clients/hedera/mirror-node/client.go
@@ -106,7 +106,7 @@ func (c Client) GetMessagesForTopicBetween(topicId hedera.TopicID, from, to int6
 	return res, nil
 }
 
-func (c Client) GetAccountTransaction(transactionID string) (*Response, error) {
+func (c Client) GetTransaction(transactionID string) (*Response, error) {
 	transactionsDownloadQuery := fmt.Sprintf("/%s",
 		transactionID)
 	return c.getTransactionsByQuery(transactionsDownloadQuery)
@@ -168,7 +168,7 @@ func (c Client) WaitForTransaction(txId string, onSuccess, onFailure func()) {
 	queryableTxId := parseIntoQueryableTx(txId)
 	go func() {
 		for {
-			response, err := c.GetAccountTransaction(queryableTxId)
+			response, err := c.GetTransaction(queryableTxId)
 			if response != nil && response.isNotFound() {
 				continue
 			}

--- a/app/clients/hedera/mirror-node/client.go
+++ b/app/clients/hedera/mirror-node/client.go
@@ -145,6 +145,23 @@ func (c Client) AccountExists(accountID hedera.AccountID) bool {
 	return true
 }
 
+func (c Client) TopicExists(topicID hedera.TopicID) bool {
+	mirrorNodeApiTransactionAddress := fmt.Sprintf("%s%s", c.mirrorAPIAddress, "topics")
+	accountQuery := fmt.Sprintf("%s/%s",
+		mirrorNodeApiTransactionAddress,
+		topicID.String())
+	response, e := c.httpClient.Get(accountQuery)
+	if e != nil {
+		return false
+	}
+
+	if response.StatusCode != 200 {
+		return false
+	}
+
+	return true
+}
+
 // WaitForTransaction Polls the transaction at intervals. Depending on the
 // result, the corresponding `onSuccess` and `onFailure` functions are called
 func (c Client) WaitForTransaction(txId string, onSuccess, onFailure func()) {

--- a/app/clients/hedera/mirror-node/client.go
+++ b/app/clients/hedera/mirror-node/client.go
@@ -147,7 +147,7 @@ func (c Client) AccountExists(accountID hedera.AccountID) bool {
 
 func (c Client) TopicExists(topicID hedera.TopicID) bool {
 	mirrorNodeApiTransactionAddress := fmt.Sprintf("%s%s", c.mirrorAPIAddress, "topics")
-	accountQuery := fmt.Sprintf("%s/%s",
+	accountQuery := fmt.Sprintf("%s/%s/messages",
 		mirrorNodeApiTransactionAddress,
 		topicID.String())
 	response, e := c.httpClient.Get(accountQuery)

--- a/app/domain/client/mirror-node.go
+++ b/app/domain/client/mirror-node.go
@@ -29,9 +29,14 @@ type MirrorNode interface {
 	GetMessagesAfterTimestamp(topicId hedera.TopicID, from int64) ([]mirror_node.Message, error)
 	// GetMessagesForTopicBetween returns all topic messages for a given topic between timestamp `from` included and `to` excluded
 	GetMessagesForTopicBetween(topicId hedera.TopicID, from, to int64) ([]mirror_node.Message, error)
-	GetAccountTransaction(transactionID string) (*mirror_node.Response, error)
+	// GetTransaction gets all data related to a specific transaction id or returns an error
+	GetTransaction(transactionID string) (*mirror_node.Response, error)
+	// GetStateProof sends a query to get the state proof. If the query is successful, the function returns the state.
+	// If the query returns a status != 200, the function returns an error.
 	GetStateProof(transactionID string) ([]byte, error)
+	// AccountExists sends a query to check whether a specific account exists. If the query returns a status != 200, the function returns a false value
 	AccountExists(accountID hedera.AccountID) bool
+	// TopicExists sends a query to check whether a specific topic exists. If the query returns a status != 200, the function returns a false value
 	TopicExists(topicID hedera.TopicID) bool
 	// WaitForTransaction Polls the transaction at intervals. Depending on the
 	// result, the corresponding `onSuccess` and `onFailure` functions are called

--- a/app/domain/client/mirror-node.go
+++ b/app/domain/client/mirror-node.go
@@ -32,6 +32,7 @@ type MirrorNode interface {
 	GetAccountTransaction(transactionID string) (*mirror_node.Response, error)
 	GetStateProof(transactionID string) ([]byte, error)
 	AccountExists(accountID hedera.AccountID) bool
+	TopicExists(topicID hedera.TopicID) bool
 	// WaitForTransaction Polls the transaction at intervals. Depending on the
 	// result, the corresponding `onSuccess` and `onFailure` functions are called
 	WaitForTransaction(txId string, onSuccess, onFailure func())

--- a/app/process/watcher/message/watcher.go
+++ b/app/process/watcher/message/watcher.go
@@ -72,10 +72,15 @@ func (cmw Watcher) Watch(q *pair.Queue) {
 		} else {
 			cmw.logger.Fatalf("Failed to fetch last Topic Watcher timestamp. Error [%s]", err)
 		}
-	} else {
-		cmw.updateStatusTimestamp(cmw.startTimestamp)
 	}
+
+	if !cmw.client.TopicExists(cmw.topicID) {
+		cmw.logger.Errorf("Error incoming: Could not start monitoring topic [%s] - Topic not found.", cmw.topicID.String())
+		return
+	}
+
 	cmw.beginWatching(q)
+	cmw.logger.Infof("Watching for Messages after Timestamp [%s]", timestamp.ToHumanReadable(cmw.startTimestamp))
 }
 
 func (cmw Watcher) updateStatusTimestamp(ts int64) {

--- a/app/process/watcher/message/watcher.go
+++ b/app/process/watcher/message/watcher.go
@@ -61,7 +61,7 @@ func NewWatcher(client client.MirrorNode, topicID string, repository repository.
 
 func (cmw Watcher) Watch(q *pair.Queue) {
 	if !cmw.client.TopicExists(cmw.topicID) {
-		cmw.logger.Errorf("Error incoming: Could not start monitoring topic [%s] - Topic not found.", cmw.topicID.String())
+		cmw.logger.Errorf("Could not start monitoring topic [%s] - Topic not found.", cmw.topicID.String())
 		return
 	}
 

--- a/app/process/watcher/message/watcher.go
+++ b/app/process/watcher/message/watcher.go
@@ -78,10 +78,7 @@ func (cmw Watcher) Watch(q *pair.Queue) {
 			cmw.logger.Fatalf("Failed to fetch last Topic Watcher timestamp. Error [%s]", err)
 		}
 	} else {
-		err := cmw.statusRepository.UpdateLastFetchedTimestamp(topic, cmw.startTimestamp)
-		if err != nil {
-			cmw.logger.Fatalf("Failed to update Topic Watcher timestamp. Error [%s]", err)
-		}
+		cmw.updateStatusTimestamp(cmw.startTimestamp)
 	}
 
 	cmw.beginWatching(q)

--- a/app/process/watcher/message/watcher.go
+++ b/app/process/watcher/message/watcher.go
@@ -145,7 +145,7 @@ func (cmw *Watcher) restart(q *pair.Queue) {
 	if cmw.maxRetries > 0 {
 		cmw.maxRetries--
 		cmw.logger.Infof("Watcher is trying to reconnect. Connections left [%d]", cmw.maxRetries)
-		go cmw.Watch(q)
+		go cmw.beginWatching(q)
 		return
 	}
 	cmw.logger.Errorf("Watcher failed: [Too many retries]")

--- a/app/process/watcher/message/watcher.go
+++ b/app/process/watcher/message/watcher.go
@@ -66,14 +66,10 @@ func (cmw Watcher) Watch(q *pair.Queue) {
 	}
 
 	topic := cmw.topicID.String()
-	lastFetchedTimestamp, err := cmw.statusRepository.GetLastFetchedTimestamp(topic)
+	_, err := cmw.statusRepository.GetLastFetchedTimestamp(topic)
 	if err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
-			newTimeStamp := time.Now().UnixNano()
-			if cmw.startTimestamp > 0 {
-				newTimeStamp = cmw.startTimestamp
-			}
-			err := cmw.statusRepository.CreateTimestamp(topic, newTimeStamp)
+			err := cmw.statusRepository.CreateTimestamp(topic, cmw.startTimestamp)
 			if err != nil {
 				cmw.logger.Fatalf("Failed to create Topic Watcher timestamp. Error [%s]", err)
 			}
@@ -82,12 +78,9 @@ func (cmw Watcher) Watch(q *pair.Queue) {
 			cmw.logger.Fatalf("Failed to fetch last Topic Watcher timestamp. Error [%s]", err)
 		}
 	} else {
-		if cmw.startTimestamp > 0 {
-			lastFetchedTimestamp = cmw.startTimestamp
-			err := cmw.statusRepository.UpdateLastFetchedTimestamp(topic, lastFetchedTimestamp)
-			if err != nil {
-				cmw.logger.Fatalf("Failed to update Topic Watcher timestamp. Error [%s]", err)
-			}
+		err := cmw.statusRepository.UpdateLastFetchedTimestamp(topic, cmw.startTimestamp)
+		if err != nil {
+			cmw.logger.Fatalf("Failed to update Topic Watcher timestamp. Error [%s]", err)
 		}
 	}
 

--- a/app/process/watcher/message/watcher.go
+++ b/app/process/watcher/message/watcher.go
@@ -94,7 +94,10 @@ func (cmw Watcher) updateStatusTimestamp(ts int64) {
 }
 
 func (cmw Watcher) beginWatching(q *pair.Queue) {
-	milestoneTimestamp := cmw.startTimestamp
+	milestoneTimestamp, err := cmw.statusRepository.GetLastFetchedTimestamp(cmw.topicID.String())
+	if err != nil {
+		cmw.logger.Fatalf("Failed to retrieve Topic Watcher Status timestamp. Error [%s]", err)
+	}
 
 	for {
 		messages, err := cmw.client.GetMessagesAfterTimestamp(cmw.topicID, milestoneTimestamp)
@@ -135,6 +138,7 @@ func (cmw *Watcher) restart(q *pair.Queue) {
 	if cmw.maxRetries > 0 {
 		cmw.maxRetries--
 		cmw.logger.Infof("Watcher is trying to reconnect. Connections left [%d]", cmw.maxRetries)
+		time.Sleep(5 * time.Second)
 		go cmw.beginWatching(q)
 		return
 	}

--- a/app/process/watcher/transfer/watcher.go
+++ b/app/process/watcher/transfer/watcher.go
@@ -86,12 +86,10 @@ func (ctw Watcher) Watch(q *pair.Queue) {
 		} else {
 			ctw.logger.Fatalf("Failed to fetch last Transfer Watcher timestamp. Error: [%s]", err)
 		}
-	} else {
-		ctw.updateStatusTimestamp(ctw.startTimestamp)
 	}
 
 	if !ctw.client.AccountExists(ctw.accountID) {
-		ctw.logger.Errorf("Error incoming: Could not start monitoring account - Account not found.")
+		ctw.logger.Errorf("Error incoming: Could not start monitoring account [%s] - Account not found.", ctw.accountID.String())
 		return
 	}
 

--- a/app/process/watcher/transfer/watcher.go
+++ b/app/process/watcher/transfer/watcher.go
@@ -173,7 +173,7 @@ func (ctw *Watcher) restart(q *pair.Queue) {
 	if ctw.maxRetries > 0 {
 		ctw.maxRetries--
 		ctw.logger.Infof("Watcher is trying to reconnect")
-		go ctw.Watch(q)
+		go ctw.beginWatching(q)
 		return
 	}
 	ctw.logger.Errorf("Watcher failed: [Too many retries]")

--- a/app/process/watcher/transfer/watcher.go
+++ b/app/process/watcher/transfer/watcher.go
@@ -75,7 +75,7 @@ func NewWatcher(
 
 func (ctw Watcher) Watch(q *pair.Queue) {
 	if !ctw.client.AccountExists(ctw.accountID) {
-		ctw.logger.Errorf("Error incoming: Could not start monitoring account [%s] - Account not found.", ctw.accountID.String())
+		ctw.logger.Errorf("Could not start monitoring account [%s] - Account not found.", ctw.accountID.String())
 		return
 	}
 
@@ -116,7 +116,7 @@ func (ctw Watcher) beginWatching(q *pair.Queue) {
 	for {
 		transactions, e := ctw.client.GetAccountCreditTransactionsAfterTimestamp(ctw.accountID, milestoneTimestamp)
 		if e != nil {
-			ctw.logger.Errorf("Error incoming: Suddenly stopped monitoring account - [%s]", e)
+			ctw.logger.Errorf("Suddenly stopped monitoring account - [%s]", e)
 			ctw.restart(q)
 			return
 		}

--- a/app/process/watcher/transfer/watcher.go
+++ b/app/process/watcher/transfer/watcher.go
@@ -92,10 +92,7 @@ func (ctw Watcher) Watch(q *pair.Queue) {
 			ctw.logger.Fatalf("Failed to fetch last Transfer Watcher timestamp. Error: [%s]", err)
 		}
 	} else {
-		err := ctw.statusRepository.UpdateLastFetchedTimestamp(account, ctw.startTimestamp)
-		if err != nil {
-			ctw.logger.Fatalf("Failed to update Transfer Watcher timestamp. Error [%s]", err)
-		}
+		ctw.updateStatusTimestamp(ctw.startTimestamp)
 	}
 
 	go ctw.beginWatching(q)

--- a/app/process/watcher/transfer/watcher.go
+++ b/app/process/watcher/transfer/watcher.go
@@ -80,14 +80,10 @@ func (ctw Watcher) Watch(q *pair.Queue) {
 	}
 
 	account := ctw.accountID.String()
-	lastFetchedTimestamp, err := ctw.statusRepository.GetLastFetchedTimestamp(account)
+	_, err := ctw.statusRepository.GetLastFetchedTimestamp(account)
 	if err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
-			newTimeStamp := time.Now().UnixNano()
-			if ctw.startTimestamp > 0 {
-				newTimeStamp = ctw.startTimestamp
-			}
-			err := ctw.statusRepository.CreateTimestamp(account, newTimeStamp)
+			err := ctw.statusRepository.CreateTimestamp(account, ctw.startTimestamp)
 			if err != nil {
 				ctw.logger.Fatalf("Failed to create Transfer Watcher timestamp. Error [%s]", err)
 			}
@@ -96,12 +92,9 @@ func (ctw Watcher) Watch(q *pair.Queue) {
 			ctw.logger.Fatalf("Failed to fetch last Transfer Watcher timestamp. Error: [%s]", err)
 		}
 	} else {
-		if ctw.startTimestamp > 0 {
-			lastFetchedTimestamp = ctw.startTimestamp
-			err := ctw.statusRepository.UpdateLastFetchedTimestamp(account, lastFetchedTimestamp)
-			if err != nil {
-				ctw.logger.Fatalf("Failed to update Transfer Watcher timestamp. Error [%s]", err)
-			}
+		err := ctw.statusRepository.UpdateLastFetchedTimestamp(account, ctw.startTimestamp)
+		if err != nil {
+			ctw.logger.Fatalf("Failed to update Transfer Watcher timestamp. Error [%s]", err)
 		}
 	}
 


### PR DESCRIPTION
**Detailed description**:
I changed 2 lines of code in order to skip timestamp picking and directly continue with the last timestamp in the database on watcher restart.

**Which issue(s) this PR fixes**:
Closes #190 

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

